### PR TITLE
4.0.3版本发布

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
     <dependency>
         <groupId>io.github.ramerf</groupId>
         <artifactId>wind-core</artifactId>
-        <version>4.0.2-RELEASE</version>
+        <version>4.0.3</version>
     </dependency>
     ```
     
@@ -858,11 +858,11 @@ wind:
   logic-delete-prop:
       # 是否启用逻辑删除,可以在类上使用@TableInfo(logicDelete = @LogicDelete(enable = true))属性覆盖
       enable: false
-      # 逻辑删除字段名,@TableInfo会覆盖该配置
+      # 逻辑删除字段名
       field-name: deleted
-      # 逻辑未删除值(默认为 false),@TableInfo会覆盖该配置
+      # 逻辑未删除值(默认为 false)
       not-delete: false
-      # 逻辑已删除值(默认为 true),@TableInfo会覆盖该配置
+      # 逻辑已删除值(默认为 true)
       deleted: true
   # entity所在包路径,多个以,分割
   entity-package: io.github.ramerf.wind.demo.entity.pojo

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,8 +19,8 @@
 - 更新：默认关闭逻辑删除
 - 更新：默认写入所有(包括null值)属性，通过`wind.write-null-prop=true/false`开关
 - 更新：InterEnum枚举值由整型改为泛型。controller枚举支持接收名称和value值
-- 更新：@Column替换为@TableColumn
-- 更新：弃用@Entity，使用@TableInfo
+- 更新：`@Column`替换为`@TableColumn`
+- 更新：弃用`@Entity`，使用`@TableInfo`
 - 更新：其他易用性更新
 - 优化：缓存清除时改为使用scan指令
 - 修复：字段为boolean时，lambda无法获取到field

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ---
 
-#### 4.0.2-RELEASE
+#### 4.0.3
 
 - 新增：更新指定字段
 - 新增：查询支持
@@ -12,9 +12,9 @@
 - 新增：`GenericService`支持操作任意表
 - 新增：支持内存缓存。通过`wind.cache.type=memory`开启
 - 新增：实体现在自带保存/更新方法 `product.create();`
-- 新增：枚举校验注解
 - 新增：校验器工具类
 - 新增：全局异常处理
+- 新增：Postgresql支持Set字段
 - 更新：默认关闭缓存
 - 更新：默认关闭逻辑删除
 - 更新：默认写入所有(包括null值)属性，通过`wind.write-null-prop=true/false`开关

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <groupId>io.github.ramerf</groupId>
     <artifactId>wind</artifactId>
     <name>wind</name>
-    <version>4.0.2-RELEASE</version>
+    <version>4.0.3</version>
     <modules>
         <module>wind-core</module>
     </modules>
@@ -48,7 +48,7 @@
         <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <findgugs.annotations.version>2.0.1</findgugs.annotations.version>
         <swagger-annotations.version>1.5.22</swagger-annotations.version>
-        <wind.version>4.0.2-RELEASE</wind.version>
+        <wind.version>4.0.3</wind.version>
     </properties>
     <dependencies>
         <dependency>

--- a/wind-core/pom.xml
+++ b/wind-core/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>wind</artifactId>
         <groupId>io.github.ramerf</groupId>
-        <version>4.0.2-RELEASE</version>
+        <version>4.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>wind-core</artifactId>
     <name>wind-core</name>
-    <version>4.0.2-RELEASE</version>
+    <version>4.0.3</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <postgresql.version>42.2.18</postgresql.version>

--- a/wind-core/src/main/java/io/github/ramerf/wind/core/config/LogicDeleteProp.java
+++ b/wind-core/src/main/java/io/github/ramerf/wind/core/config/LogicDeleteProp.java
@@ -1,5 +1,6 @@
 package io.github.ramerf.wind.core.config;
 
+import io.github.ramerf.wind.core.annotation.LogicDelete;
 import io.github.ramerf.wind.core.annotation.TableInfo;
 import io.github.ramerf.wind.core.entity.pojo.AbstractEntityPoJo;
 import java.io.Serializable;
@@ -43,14 +44,16 @@ public class LogicDeleteProp {
 
   public static LogicDeleteProp of(
       final TableInfo tableInfo, @Nonnull final WindConfiguration configuration) {
-    if (tableInfo == null) {
+    LogicDelete logicDelete;
+    // 如果fieldName为空,说明未指定该属性,使用全局配置
+    if (tableInfo == null || (logicDelete = tableInfo.logicDelete()).fieldName().equals("")) {
       return of(configuration);
     }
     LogicDeleteProp logicDeleteProp = new LogicDeleteProp();
-    logicDeleteProp.setEnable(tableInfo.logicDelete().enable());
-    logicDeleteProp.setFieldName(tableInfo.logicDelete().fieldName());
-    logicDeleteProp.setDeleted(tableInfo.logicDelete().deleted());
-    logicDeleteProp.setNotDelete(tableInfo.logicDelete().notDelete());
+    logicDeleteProp.setEnable(logicDelete.enable());
+    logicDeleteProp.setFieldName(logicDelete.fieldName());
+    logicDeleteProp.setDeleted(logicDelete.deleted());
+    logicDeleteProp.setNotDelete(logicDelete.notDelete());
     return logicDeleteProp;
   }
 

--- a/wind-core/src/main/java/io/github/ramerf/wind/core/dialect/postgresql/PostgreSQL81Dialect.java
+++ b/wind-core/src/main/java/io/github/ramerf/wind/core/dialect/postgresql/PostgreSQL81Dialect.java
@@ -38,16 +38,24 @@ public class PostgreSQL81Dialect extends Dialect {
 
     registerColumnType(Date.class, "timestamp");
     // array
+    registerColumnType(short[].class, "int[]");
+    registerColumnType(Short[].class, "int[]");
+    registerColumnType(JavaType.LIST_SHORT, "int[]");
+    registerColumnType(JavaType.SET_SHORT, "int[]");
+
     registerColumnType(int[].class, "int[]");
     registerColumnType(Integer[].class, "int[]");
     registerColumnType(JavaType.LIST_INTEGER, "int[]");
+    registerColumnType(JavaType.SET_INTEGER, "int[]");
 
     registerColumnType(long[].class, "bigint[]");
     registerColumnType(Long[].class, "bigint[]");
     registerColumnType(JavaType.LIST_LONG, "bigint[]");
+    registerColumnType(JavaType.SET_LONG, "bigint[]");
 
     registerColumnType(String[].class, "text[]");
     registerColumnType(JavaType.LIST_STRING, "text[]");
+    registerColumnType(JavaType.SET_STRING, "text[]");
   }
 
   @Override
@@ -77,6 +85,13 @@ public class PostgreSQL81Dialect extends Dialect {
     addSupportedJavaType(JavaType.LIST_FLOAT);
     addSupportedJavaType(JavaType.LIST_DOUBLE);
     addSupportedJavaType(JavaType.LIST_BIGDECIMAL);
+
+    addSupportedJavaType(JavaType.SET_SHORT);
+    addSupportedJavaType(JavaType.SET_INTEGER);
+    addSupportedJavaType(JavaType.SET_LONG);
+    addSupportedJavaType(JavaType.SET_FLOAT);
+    addSupportedJavaType(JavaType.SET_DOUBLE);
+    addSupportedJavaType(JavaType.SET_BIGDECIMAL);
 
     addSupportedJavaType(JavaType.LIST_STRING);
 

--- a/wind-core/src/main/java/io/github/ramerf/wind/core/entity/response/ResultCode.java
+++ b/wind-core/src/main/java/io/github/ramerf/wind/core/entity/response/ResultCode.java
@@ -3,77 +3,75 @@ package io.github.ramerf.wind.core.entity.response;
 import lombok.ToString;
 
 /**
- * 返回结果码,名称前缀为模块简拼.
+ * 返回结果码.
  *
+ * @since 2020.12.22
  * @author Tang Xiaofeng
- * @since 2019/12/5
  */
 @ToString
-@SuppressWarnings("all")
 public class ResultCode {
   // 凭证
-  public static final ResultCode API_WRONG_PARAM = of("E0100", "参数错误");
-  public static final ResultCode API_CERT_NOT_EXIST = of("E0101", "未知凭证");
-  public static final ResultCode API_CERT_WRONG_FORMAT = of("E0102", "参数签名有误");
-  public static final ResultCode API_CERT_SECRET_EXPIRE = of("E0103", "凭证已过期");
-  public static final ResultCode API_CERT_SECRET_EMPTY = of("E0104", "凭证不能为空");
-  public static final ResultCode API_CERT_DISABLED = of("E0105", "凭证已被禁用");
-  public static final ResultCode API_CERT_UNKNOWN_ERROR = of("E0106", "其他原因");
+  public static final ResultCode API_WRONG_PARAM = of(100, "参数错误");
+  public static final ResultCode API_CERT_NOT_EXIST = of(101, "未知凭证");
+  public static final ResultCode API_CERT_WRONG_FORMAT = of(102, "参数签名有误");
+  public static final ResultCode API_CERT_SECRET_EXPIRE = of(103, "凭证已过期");
+  public static final ResultCode API_CERT_SECRET_EMPTY = of(104, "凭证不能为空");
+  public static final ResultCode API_CERT_DISABLED = of(105, "凭证已被禁用");
+  public static final ResultCode API_CERT_UNKNOWN_ERROR = of(106, "其他原因");
   // 公共信息
-  public static final ResultCode SUCCESS = of("E0000", "操作成功");
-  public static final ResultCode ERROR = of("E0001", "系统繁忙,请稍后再试 !");
-  public static final ResultCode API_UNAUTHORIZED = of("E0002", "未认证");
-  public static final ResultCode API_FORBIDDEN = of("E0003", "无访问权限");
-  public static final ResultCode API_NOT_IMPLEMENT = of("E0004", "方法未实现");
-  public static final ResultCode API_SERVICE_NOT_AVAILABLE = of("E0005", "服务不可用");
-  public static final ResultCode API_NOT_FOUND = of("E0006", "资源不可用");
-  public static final ResultCode ERROR_DATA_ACCESS = of("E0007", "%s");
+  public static final ResultCode SUCCESS = of(0, "操作成功");
+  public static final ResultCode ERROR = of(1, "系统繁忙,请稍后再试 !");
+  public static final ResultCode API_UNAUTHORIZED = of(2, "未认证");
+  public static final ResultCode API_FORBIDDEN = of(3, "无访问权限");
+  public static final ResultCode API_NOT_IMPLEMENT = of(4, "方法未实现");
+  public static final ResultCode API_SERVICE_NOT_AVAILABLE = of(5, "服务不可用");
+  public static final ResultCode API_NOT_FOUND = of(6, "资源不可用");
+  public static final ResultCode ERROR_DATA_ACCESS = of(7, "%s");
   // 操作成功提示
-  public static final ResultCode API_SUCCESS_EXEC_CREATE = of("E1100", "添加成功");
-  public static final ResultCode API_SUCCESS_EXEC_UPDATE = of("E1101", "更新成功");
-  public static final ResultCode API_SUCCESS_EXEC_DELETE = of("E1102", "删除成功");
+  public static final ResultCode API_SUCCESS_EXEC_CREATE = of(1100, "添加成功");
+  public static final ResultCode API_SUCCESS_EXEC_UPDATE = of(1101, "更新成功");
+  public static final ResultCode API_SUCCESS_EXEC_DELETE = of(1102, "删除成功");
   // 操作失败提示
-  public static final ResultCode API_FAIL_EXEC = of("E1201", "操作失败,数据格式有误");
-  public static final ResultCode API_FAIL_EXEC_CREATE = of("E1201", "添加失败,数据格式有误");
-  public static final ResultCode API_FAIL_EXEC_CREATE_EXIST = of("E1202", "添加失败,数据已存在");
-  public static final ResultCode API_FAIL_EXEC_UPDATE = of("E1203", "更新失败,数据格式有误");
-  public static final ResultCode API_FAIL_EXEC_UPDATE_NOT_EXIST = of("E1204", "更新失败,记录不存在");
-  public static final ResultCode API_FAIL_EXEC_DELETE = of("E1205", "删除失败");
-  public static final ResultCode API_FAIL_EXEC_DELETE_BATCH = of("E1206", "批量删除失败,可能数据已被删除");
-  public static final ResultCode API_FAIL_DELETE_NO_CONDITION = of("E1207", "删除失败,条件不能为空");
+  public static final ResultCode API_FAIL_EXEC = of(1201, "操作失败,数据格式有误");
+  public static final ResultCode API_FAIL_EXEC_CREATE = of(1201, "添加失败,数据格式有误");
+  public static final ResultCode API_FAIL_EXEC_CREATE_EXIST = of(1202, "添加失败,数据已存在");
+  public static final ResultCode API_FAIL_EXEC_UPDATE = of(1203, "更新失败,数据格式有误");
+  public static final ResultCode API_FAIL_EXEC_UPDATE_NOT_EXIST = of(1204, "更新失败,记录不存在");
+  public static final ResultCode API_FAIL_EXEC_DELETE = of(1205, "删除失败");
+  public static final ResultCode API_FAIL_EXEC_DELETE_BATCH = of(1206, "批量删除失败,可能数据已被删除");
+  public static final ResultCode API_FAIL_DELETE_NO_CONDITION = of(1207, "删除失败,条件不能为空");
   /// 参数
-  public static final ResultCode API_NOT_ALLOWED = of("E1301", "操作不允许:[%s]");
-  public static final ResultCode API_PARAM_WRONG_FORMAT = of("E1302", "参数格式不正确:[%s]");
-  public static final ResultCode API_PARAM_WRONG_VALUE = of("E1303", "参数值不正确:[%s]");
-  public static final ResultCode API_PARAM_CAN_NOT_BLANK = of("E1304", "参数值不能为空:[%s]");
-  public static final ResultCode API_PARAM_NOT_PRESENT = of("E1305", "参数未传递:[%s]");
-  public static final ResultCode API_PARAM_INVALID = of("E1306", "参数值无效:[%s]");
-  public static final ResultCode API_PARAM_BIND_ERROR = of("E1307", "参数值有误: \n");
-  public static final ResultCode API_DATA_EXIST = of("E1308", "数据已存在:[%s]");
-  public static final ResultCode API_DATA_NOT_EXIST = of("E1309", "数据不存在:[%s]");
-  public static final ResultCode API_CONTENT_TYPE_NOT_SUPPORT =
-      of("E1310", "请求ContentType不支持:[%s]");
-  public static final ResultCode API_METHOD_NOT_SUPPORT = of("E1311", "请求方式不支持:[%s]");
-  public static final ResultCode API_TOO_MANY_RESULTS = of("E1312", "返回结果过多");
-  public static final ResultCode API_UPDATE_ID_NOT_EMPTY = of("E1313", "id 不能为空");
+  public static final ResultCode API_NOT_ALLOWED = of(1301, "操作不允许:[%s]");
+  public static final ResultCode API_PARAM_WRONG_FORMAT = of(1302, "参数格式不正确:[%s]");
+  public static final ResultCode API_PARAM_WRONG_VALUE = of(1303, "参数值不正确:[%s]");
+  public static final ResultCode API_PARAM_CAN_NOT_BLANK = of(1304, "参数值不能为空:[%s]");
+  public static final ResultCode API_PARAM_NOT_PRESENT = of(1305, "参数未传递:[%s]");
+  public static final ResultCode API_PARAM_INVALID = of(1306, "参数值无效:[%s]");
+  public static final ResultCode API_PARAM_BIND_ERROR = of(1307, "参数值有误: \n");
+  public static final ResultCode API_DATA_EXIST = of(1308, "数据已存在:[%s]");
+  public static final ResultCode API_DATA_NOT_EXIST = of(1309, "数据不存在:[%s]");
+  public static final ResultCode API_CONTENT_TYPE_NOT_SUPPORT = of(1310, "请求ContentType不支持:[%s]");
+  public static final ResultCode API_METHOD_NOT_SUPPORT = of(1311, "请求方式不支持:[%s]");
+  public static final ResultCode API_TOO_MANY_RESULTS = of(1312, "返回结果过多");
+  public static final ResultCode API_UPDATE_ID_NOT_EMPTY = of(1313, "id 不能为空");
 
-  protected String code;
+  protected int code;
   protected String desc;
 
   public boolean isSuccess() {
-    return code.equals(SUCCESS.code);
+    return code == SUCCESS.code;
   }
 
-  protected ResultCode(final String code, final String desc) {
+  protected ResultCode(final int code, final String desc) {
     this.code = code;
     this.desc = desc;
   }
 
-  public static ResultCode of(final String code, final String desc) {
+  public static ResultCode of(final int code, final String desc) {
     return new ResultCode(code, desc);
   }
 
-  public String code() {
+  public int code() {
     return code;
   }
 

--- a/wind-core/src/main/java/io/github/ramerf/wind/core/entity/response/Rs.java
+++ b/wind-core/src/main/java/io/github/ramerf/wind/core/entity/response/Rs.java
@@ -2,7 +2,6 @@ package io.github.ramerf.wind.core.entity.response;
 
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.serializer.*;
-import io.github.ramerf.wind.core.exception.CommonException;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.Serializable;
@@ -19,17 +18,17 @@ import org.springframework.http.ResponseEntity;
 /**
  * 通用JSON响应.
  *
- * @since 2019.12.05
- * @author Tang Xiaofeng
  * @param <T> the type parameter
+ * @since 2020.12.22
+ * @author Tang Xiaofeng
  */
 @Data
 @ApiModel("通用响应")
-@SuppressWarnings("unused")
 public class Rs<T> implements Serializable {
-  /** 请求处理结果: 成功/失败 */
-  @ApiModelProperty(value = "请求处理结果: 成功/失败", example = "true")
-  private boolean result = true;
+
+  /** {@link ResultCode#code()} */
+  @ApiModelProperty(value = "请求结果CODE,0表示成功", example = "0")
+  private int code = ResultCode.SUCCESS.code();
 
   /** 请求成功时,该值是具体返回内容,否则为空 */
   @ApiModelProperty(value = "请求成功时,该值是具体返回内容,否则为空", example = "{name: '名称',value: '值'}")
@@ -39,32 +38,32 @@ public class Rs<T> implements Serializable {
   @ApiModelProperty(value = "描述", example = "操作成功")
   private String msg = ResultCode.SUCCESS.desc();
 
-  /** {@link ResultCode#code()} */
-  @ApiModelProperty(value = "请求结果CODE", example = "E0001")
-  private String code = ResultCode.SUCCESS.code();
-
   /** 时间戳 */
   @ApiModelProperty(value = "请求响应时间戳", example = "1575435889491")
   private long timestamp = System.currentTimeMillis();
 
-  private static final List<String> excludeUrl = new ArrayList<>();
+  private Rs() {}
 
-  static {
-    excludeUrl.add("inner");
-    excludeUrl.add("outer");
+  /**
+   * Of rs.
+   *
+   * @param <T> the type parameter
+   * @return the rs
+   */
+  public static <T> Rs<T> of() {
+    return new Rs<>();
   }
 
   /**
    * Of rs.
    *
-   * @param <R> the type parameter
-   * @param result the result
+   * @param <T> the type parameter
+   * @param data the data
    * @return the rs
    */
-  public static <R> Rs<R> of(final boolean result) {
-    Rs<R> rs = new Rs<>();
-    rs.setResult(result);
-    rs.setData(null);
+  public static <T> Rs<T> of(final T data) {
+    Rs<T> rs = new Rs<>();
+    rs.setData(data);
     return rs;
   }
 
@@ -72,14 +71,42 @@ public class Rs<T> implements Serializable {
    * Of rs.
    *
    * @param <T> the type parameter
-   * @param <R> the type parameter
+   * @param msg the msg
+   * @return the rs
+   */
+  public static <T> Rs<T> of(final String msg) {
+    Rs<T> rs = new Rs<>();
+    rs.setMsg(msg);
+    return rs;
+  }
+
+  /**
+   * Of rs.
+   *
+   * @param <T> the type parameter
+   * @param data the data
+   * @param msg the msg
+   * @return the rs
+   */
+  public static <T> Rs<T> of(final T data, final String msg) {
+    Rs<T> rs = new Rs<>();
+    rs.setData(data);
+    rs.setMsg(msg);
+    return rs;
+  }
+
+  /**
+   * Of rs.
+   *
+   * @param <T> the type parameter
+   * @param code the code
    * @param data the data
    * @return the rs
    */
-  @SuppressWarnings("unchecked")
-  public static <T, R> Rs<R> of(final T data) {
-    Rs<R> rs = new Rs<>();
-    rs.setData((R) data);
+  public static <T> Rs<T> of(final int code, final T data) {
+    Rs<T> rs = new Rs<>();
+    rs.setCode(code);
+    rs.setData(data);
     return rs;
   }
 
@@ -101,85 +128,13 @@ public class Rs<T> implements Serializable {
    * Of rs.
    *
    * @param <T> the type parameter
-   * @param <R> the type parameter
-   * @param result the result
-   * @param data the data
-   * @return the rs
-   */
-  @SuppressWarnings("unchecked")
-  public static <T, R> Rs<R> of(final boolean result, final T data) {
-    Rs<R> rs = new Rs<>();
-    rs.setResult(result);
-    rs.setData((R) data);
-    return rs;
-  }
-
-  /**
-   * Of rs.
-   *
-   * @param <T> the type parameter
-   * @param <R> the type parameter
-   * @param data the data
-   * @param msg the msg
-   * @return the rs
-   */
-  @SuppressWarnings("unchecked")
-  public static <T, R> Rs<R> of(final T data, final String msg) {
-    Rs<R> rs = new Rs<>();
-    rs.setData((R) data);
-    rs.setMsg(msg);
-    return rs;
-  }
-
-  /**
-   * Of rs.
-   *
-   * @param <R> the type parameter
-   * @param result the result
-   * @param msg the msg
-   * @return the rs
-   */
-  public static <R> Rs<R> of(final boolean result, final String msg) {
-    Rs<R> rs = new Rs<>();
-    rs.setResult(result);
-    rs.setMsg(msg);
-    return rs;
-  }
-
-  /**
-   * Of rs.
-   *
-   * @param <T> the type parameter
-   * @param <R> the type parameter
-   * @param result the result
-   * @param data the data
-   * @param msg the msg
-   * @return the rs
-   */
-  @SuppressWarnings("unchecked")
-  public static <T, R> Rs<R> of(final boolean result, final T data, final String msg) {
-    Rs<R> rs = new Rs<>();
-    rs.setResult(result);
-    rs.setData((R) data);
-    rs.setMsg(msg);
-    return rs;
-  }
-
-  /**
-   * Of rs.
-   *
-   * @param <T> the type parameter
-   * @param <R> the type parameter
-   * @param result the result
    * @param data the data
    * @param resultCode the result code
    * @return the rs
    */
-  @SuppressWarnings("unchecked")
-  public static <T, R> Rs<R> of(final boolean result, final T data, final ResultCode resultCode) {
-    Rs<R> rs = new Rs<>();
-    rs.setResult(result);
-    rs.setData((R) data);
+  public static <T> Rs<T> of(final T data, final ResultCode resultCode) {
+    Rs<T> rs = new Rs<>();
+    rs.setData(data);
     rs.setMsg(resultCode.desc());
     rs.setCode(resultCode.code());
     return rs;
@@ -188,34 +143,34 @@ public class Rs<T> implements Serializable {
   /**
    * Of rs.
    *
-   * @param <R> the type parameter
-   * @param result the result
-   * @param resultCode the result code
+   * @param <T> the type parameter
+   * @param code the code
+   * @param data the data
+   * @param msg the msg
    * @return the rs
    */
-  public static <R> Rs<R> of(final boolean result, final ResultCode resultCode) {
-    Rs<R> rs = new Rs<>();
-    rs.setResult(result);
-    rs.setMsg(resultCode.desc());
-    rs.setCode(resultCode.code());
+  public static <T> Rs<T> of(final int code, final T data, final String msg) {
+    Rs<T> rs = new Rs<>();
+    rs.setCode(code);
+    rs.setData(data);
+    rs.setMsg(msg);
     return rs;
   }
 
   /**
    * 默认执行成功构造器.
    *
-   * @param <R> the type parameter
+   * @param <T> the type parameter
    * @return the response entity
    */
-  public static <R> Rs<R> ok() {
-    return Rs.of(true);
+  public static <T> Rs<T> ok() {
+    return Rs.of();
   }
 
   /**
    * Ok response entity.
    *
    * @param <T> the type parameter
-   * @param <R> the type parameter
    * @param data the data
    * @return the response entity
    */
@@ -226,90 +181,66 @@ public class Rs<T> implements Serializable {
   /**
    * Ok response entity.
    *
-   * @param <R> the type parameter
-   * @param data the data
-   * @return the response entity
-   */
-  public static <R> Rs<R> ok(final ResultCode data) {
-    return Rs.of(data);
-  }
-
-  /**
-   * Ok response entity.
-   *
    * @param <T> the type parameter
-   * @param <R> the type parameter
-   * @param data the data
-   * @param resultCode the result code
-   * @return the response entity
-   */
-  public static <T, R> Rs<R> ok(final T data, final ResultCode resultCode) {
-    return Rs.of(true, data, resultCode);
-  }
-
-  /**
-   * Ok response entity.
-   *
-   * @param <T> the type parameter
-   * @param <R> the type parameter
    * @param data the data
    * @param msg the msg
    * @return the response entity
    */
-  public static <T, R> Rs<R> ok(final T data, final String msg) {
+  public static <T> Rs<T> ok(final T data, final String msg) {
     return Rs.of(data, msg);
+  }
+
+  /**
+   * Ok response entity.
+   *
+   * @param <T> the type parameter
+   * @param resultCode the result code
+   * @return the response entity
+   */
+  public static <T> Rs<T> ok(final ResultCode resultCode) {
+    return Rs.of(resultCode);
+  }
+
+  /**
+   * Ok response entity.
+   *
+   * @param <T> the type parameter
+   * @param data the data
+   * @param resultCode the result code
+   * @return the response entity
+   */
+  public static <T> Rs<T> ok(final T data, final ResultCode resultCode) {
+    return Rs.of(data, resultCode);
   }
 
   /**
    * 成功返回空的{@link Page}对象.
    *
-   * @param <R> the type parameter
+   * @param <T> the type parameter
    * @return the response entity
    */
-  public static <R> Rs<PageImpl<R>> emptyPage() {
+  public static <T> Rs<PageImpl<T>> emptyPage() {
     return Rs.of(new PageImpl<>(Collections.emptyList()));
   }
 
   /**
    * 成功返回空的l{@link List}对象.
    *
-   * @param <R> the type parameter
+   * @param <T> the type parameter
    * @return the response entity
    */
-  public static <R> Rs<List<R>> emptyList() {
+  public static <T> Rs<List<T>> emptyList() {
     return Rs.of(Collections.emptyList());
   }
 
   /**
    * 默认执行失败构造器.
    *
-   * @param <R> the type parameter
+   * @param <T> the type parameter
    * @return the response entity
    */
-  public static <R> Rs<R> fail() {
-    return Rs.of(false, ResultCode.ERROR);
-  }
-
-  /**
-   * Fail response entity.
-   *
-   * @param <R> the type parameter
-   * @param data the data
-   * @return the response entity
-   */
-  public static <R> Rs<R> fail(final ResultCode data) {
-    return Rs.of(false, data);
-  }
-
-  /**
-   * Fail response entity.
-   *
-   * @param <R> the type parameter
-   * @param msg the msg
-   * @return the response entity
-   */
-  public static <R> Rs<R> fail(final String msg) {
-    return Rs.of(false, ResultCode.of(ResultCode.ERROR.code(), msg));
+  public static <T> Rs<T> fail() {
+    return Rs.of(ResultCode.ERROR);
   }
 
   /**
@@ -317,11 +248,77 @@ public class Rs<T> implements Serializable {
    *
    * @param <T> the type parameter
    * @param msg the msg
-   * @param data the data
    * @return the response entity
    */
-  public static <T> Rs<T> fail(final String msg, final T data) {
-    return Rs.of(false, data, msg);
+  public static <T> Rs<T> fail(final String msg) {
+    return Rs.of(ResultCode.of(ResultCode.ERROR.code(), msg));
+  }
+
+  /**
+   * Fail response entity.
+   *
+   * @param <T> the type parameter
+   * @param data the data
+   * @param msg the msg
+   * @return the response entity
+   */
+  public static <T> Rs<T> fail(final T data, final String msg) {
+    return Rs.of(data, msg);
+  }
+
+  /**
+   * Fail response entity.
+   *
+   * @param <T> the type parameter
+   * @param resultCode the result code
+   * @return the response entity
+   */
+  public static <T> Rs<T> fail(final ResultCode resultCode) {
+    return Rs.of(resultCode);
+  }
+
+  /**
+   * 参数格式不正确.
+   *
+   * @param <T> the type parameter
+   * @param field the field
+   * @return the response entity
+   */
+  public static <T> Rs<T> wrongFormat(final String field) {
+    return Rs.of(ResultCode.API_PARAM_WRONG_FORMAT.desc(field));
+  }
+
+  /**
+   * 参数值不正确.
+   *
+   * @param <T> the type parameter
+   * @param field the field
+   * @return the response entity
+   */
+  public static <T> Rs<T> wrongValue(final String field) {
+    return Rs.of(ResultCode.API_PARAM_WRONG_VALUE.desc(field));
+  }
+
+  /**
+   * 参数值不能为空
+   *
+   * @param <T> the type parameter
+   * @param field the field
+   * @return the response entity
+   */
+  public static <T> Rs<T> canNotBlank(final String field) {
+    return Rs.of(ResultCode.API_PARAM_CAN_NOT_BLANK.desc(field));
+  }
+
+  /**
+   * 参数值未传递
+   *
+   * @param <T> the type parameter
+   * @param field the field
+   * @return the response entity
+   */
+  public static <T> Rs<T> notPresent(final String field) {
+    return Rs.of(ResultCode.API_PARAM_NOT_PRESENT.desc(field));
   }
 
   /**
@@ -331,7 +328,7 @@ public class Rs<T> implements Serializable {
    * @return the response entity
    */
   public static <T> ResponseEntity<Rs<T>> forbidden() {
-    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Rs.of(false, ResultCode.API_FORBIDDEN));
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Rs.of(ResultCode.API_FORBIDDEN));
   }
 
   /**
@@ -341,7 +338,7 @@ public class Rs<T> implements Serializable {
    */
   public static ResponseEntity<Rs<Object>> secretExpire() {
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-        .body(Rs.of(false, ResultCode.API_CERT_SECRET_EXPIRE));
+        .body(Rs.of(ResultCode.API_CERT_SECRET_EXPIRE));
   }
 
   /**
@@ -351,7 +348,7 @@ public class Rs<T> implements Serializable {
    */
   public static ResponseEntity<Rs<Object>> secretEmpty() {
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-        .body(Rs.of(false, ResultCode.API_CERT_SECRET_EMPTY));
+        .body(Rs.of(ResultCode.API_CERT_SECRET_EMPTY));
   }
 
   /**
@@ -360,8 +357,7 @@ public class Rs<T> implements Serializable {
    * @return the response entity
    */
   public static ResponseEntity<Rs<Object>> unauthorized() {
-    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-        .body(Rs.of(false, ResultCode.API_UNAUTHORIZED));
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Rs.of(ResultCode.API_UNAUTHORIZED));
   }
 
   /**
@@ -372,186 +368,84 @@ public class Rs<T> implements Serializable {
    */
   public static ResponseEntity<Rs<Object>> notAllowed(final String msg) {
     return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
-        .body(Rs.of(false, ResultCode.API_NOT_ALLOWED.desc(msg)));
-  }
-
-  /**
-   * 参数格式不正确.
-   *
-   * @param <R> the type parameter
-   * @param field the field
-   * @return the response entity
-   */
-  public static <R> Rs<R> wrongFormat(final String field) {
-    return Rs.of(false, ResultCode.API_PARAM_WRONG_FORMAT.desc(field));
-  }
-
-  /**
-   * 参数值不正确.
-   *
-   * @param <R> the type parameter
-   * @param field the field
-   * @return the response entity
-   */
-  public static <R> Rs<R> wrongValue(final String field) {
-    return Rs.of(false, ResultCode.API_PARAM_WRONG_VALUE.desc(field));
-  }
-
-  /**
-   * 参数值不能为空
-   *
-   * @param <R> the type parameter
-   * @param field the field
-   * @return the response entity
-   */
-  public static <R> Rs<R> canNotBlank(final String field) {
-    return Rs.of(false, ResultCode.API_PARAM_CAN_NOT_BLANK.desc(field));
-  }
-
-  /**
-   * 参数值未传递
-   *
-   * @param <R> the type parameter
-   * @param field the field
-   * @return the response entity
-   */
-  public static <R> Rs<R> notPresent(final String field) {
-    return Rs.of(false, ResultCode.API_PARAM_NOT_PRESENT.desc(field));
+        .body(Rs.of(ResultCode.API_NOT_ALLOWED.desc(msg)));
   }
 
   /**
    * 资源不可用
    *
-   * @param <R> the type parameter
+   * @param <T> the type parameter
    * @return the response entity
    */
-  public static <R> ResponseEntity<Rs<R>> notFound() {
-    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Rs.of(false, ResultCode.API_NOT_FOUND));
+  public static <T> ResponseEntity<Rs<T>> notFound() {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Rs.of(ResultCode.API_NOT_FOUND));
   }
 
   /**
    * 请求Content-type不支持
    *
-   * @param <R> the type parameter
+   * @param <T> the type parameter
    * @param contentType the content type
    * @return the response entity
    */
-  public static <R> ResponseEntity<Rs<R>> notSupportMediaType(final String contentType) {
+  public static <T> ResponseEntity<Rs<T>> notSupportMediaType(final String contentType) {
     return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
-        .body(Rs.of(false, ResultCode.API_CONTENT_TYPE_NOT_SUPPORT.desc(contentType)));
+        .body(Rs.of(ResultCode.API_CONTENT_TYPE_NOT_SUPPORT.desc(contentType)));
   }
 
   /**
    * 请求方式不支持
    *
-   * @param <R> the type parameter
+   * @param <T> the type parameter
    * @param method the method
    * @return the response entity
    */
-  public static <R> ResponseEntity<Rs<R>> notSupportRequestMethod(final String method) {
+  public static <T> ResponseEntity<Rs<T>> notSupportRequestMethod(final String method) {
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-        .body(Rs.of(false, ResultCode.API_METHOD_NOT_SUPPORT.desc(method)));
+        .body(Rs.of(ResultCode.API_METHOD_NOT_SUPPORT.desc(method)));
   }
 
   /**
    * 返回结果过多
    *
-   * @param <R> the type parameter
-   * @param method the method
+   * @param <T> the type parameter
    * @return the response entity
    */
-  public static <R> Rs<R> tooManyResults(final String method) {
-    return Rs.of(false, ResultCode.API_TOO_MANY_RESULTS.desc(method));
+  public static <T> Rs<T> tooManyResults() {
+    return Rs.of(ResultCode.API_TOO_MANY_RESULTS);
   }
 
   /**
    * 参数值无效.
    *
-   * @param <R> the type parameter
+   * @param <T> the type parameter
    * @param field the field
    * @return the response entity
    */
-  public static <R> Rs<R> invalid(final String field) {
-    return Rs.of(false, ResultCode.API_PARAM_INVALID.desc(field));
+  public static <T> Rs<T> invalid(final String field) {
+    return Rs.of(ResultCode.API_PARAM_INVALID.desc(field));
   }
 
   /**
    * 数据已存在.
    *
-   * @param <R> the type parameter
+   * @param <T> the type parameter
    * @param data the data
    * @return the response entity
    */
-  public static <R> Rs<R> exist(final String data) {
-    return Rs.of(false, ResultCode.API_DATA_EXIST.desc(data));
+  public static <T> Rs<T> exist(final String data) {
+    return Rs.of(ResultCode.API_DATA_EXIST.desc(data));
   }
 
   /**
    * 数据不存在.
    *
-   * @param <R> the type parameter
+   * @param <T> the type parameter
    * @param data the data
    * @return the response entity
    */
-  public static <R> Rs<R> notExist(final String data) {
-    return Rs.of(false, ResultCode.API_DATA_NOT_EXIST.desc(data));
-  }
-
-  /**
-   * 接口调用判断,如果出现网络异常(如中断),抛出{@link CommonException#of(ResultCode)}.
-   *
-   * @param <R> the type parameter
-   * @param responseEntity 接口返回
-   * @return 请求数据实体 r
-   * @see #requireNonNull(ResponseEntity, ResultCode) #requireNonNull(ResponseEntity,
-   *     ResultCode)#requireNonNull(ResponseEntity, ResultCode)
-   */
-  public static <R> R requireNonNull(ResponseEntity<Rs<R>> responseEntity) {
-    return requireNonNull(responseEntity, ResultCode.ERROR);
-  }
-
-  /**
-   * 接口调用判断.
-   *
-   * @param <R> the type parameter
-   * @param responseEntity REST接口响应
-   * @param resultCode 返回该结果码,当满足以下任一条件时:<br>
-   *     1. <code>responseEntity</code>为空<br>
-   *     2. <code>responseEntity.body</code>为空<br>
-   * @return Rs内的对象 r
-   */
-  public static <R> R requireNonNull(
-      final ResponseEntity<Rs<R>> responseEntity, @Nonnull final ResultCode resultCode) {
-    if (Objects.isNull(responseEntity) || !responseEntity.hasBody()) {
-      throw CommonException.of(resultCode);
-    }
-    final Rs<R> body = responseEntity.getBody();
-    if (!Objects.requireNonNull(body, resultCode.desc).isResult()) {
-      throw CommonException.of(ResultCode.of(body.code, body.msg));
-    }
-    return body.data;
-  }
-
-  /**
-   * 判断ResultCode是否=SUCCESS <br>
-   * null也会返回true
-   *
-   * @param resultCode the result code
-   * @return the boolean
-   */
-  public static boolean isSuccess(final ResultCode resultCode) {
-    return Objects.isNull(resultCode) || Objects.equals(resultCode.code, ResultCode.SUCCESS.code);
-  }
-
-  /**
-   * 判断ResultCode是否=ERROR <br>
-   * null返回false
-   *
-   * @param resultCode the result code
-   * @return the boolean
-   */
-  public static boolean isError(final ResultCode resultCode) {
-    return Objects.nonNull(resultCode) && Objects.equals(resultCode.code, ResultCode.ERROR.code);
+  public static <T> Rs<T> notExist(final String data) {
+    return Rs.of(ResultCode.API_DATA_NOT_EXIST.desc(data));
   }
 
   /**
@@ -579,7 +473,7 @@ public class Rs<T> implements Serializable {
     public void write(
         JSONSerializer serializer, Object object, Object fieldName, Type fieldType, int features) {
       SerializeWriter serializeWriter = serializer.out;
-      log.info("write:[{}]", object.toString());
+      log.debug("write:[{}]", object.toString());
       serializeWriter.write(JSON.toJSONString(object));
     }
   }

--- a/wind-core/src/main/java/io/github/ramerf/wind/core/exception/CommonException.java
+++ b/wind-core/src/main/java/io/github/ramerf/wind/core/exception/CommonException.java
@@ -7,11 +7,10 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * 全局通用异常.
  *
+ * @since 2020.12.22
  * @author Tang Xiaofeng
- * @since 2019/11/13
  */
 @Slf4j
-@SuppressWarnings({"unused", "UnusedReturnValue"})
 public class CommonException extends RuntimeException {
   private ResultCode resultCode;
 
@@ -19,20 +18,28 @@ public class CommonException extends RuntimeException {
     return resultCode;
   }
 
+  public static CommonException of() {
+    return new CommonException();
+  }
+
   public static CommonException of(final String message) {
     return new CommonException(message);
   }
 
-  public static CommonException of(final String code, final String message) {
+  public static CommonException of(final int code, final String message) {
     return new CommonException(ResultCode.of(code, message));
+  }
+
+  public static CommonException of(final int code, final String message, final Throwable cause) {
+    return new CommonException(ResultCode.of(code, message), cause);
   }
 
   public static CommonException of(@Nonnull final ResultCode resultCode) {
     return new CommonException(resultCode);
   }
 
-  public static CommonException of() {
-    return new CommonException();
+  public static CommonException of(@Nonnull final ResultCode resultCode, final Throwable cause) {
+    return new CommonException(resultCode, cause);
   }
 
   public static CommonException of(final String message, final Throwable cause) {
@@ -43,18 +50,25 @@ public class CommonException extends RuntimeException {
     return new CommonException(cause);
   }
 
-  public static <T> T requireNonNull(T obj, String message) {
+  /** 如果对象为空,抛出异常. */
+  public static Object requireNonNull(Object obj, String message) {
     if (obj == null) {
       throw CommonException.of(message);
     }
     return obj;
   }
 
-  public static <T> T requireNonNull(T obj, final ResultCode resultcode) {
+  /** 如果对象为空,抛出异常. */
+  public static Object requireNonNull(Object obj, final ResultCode resultcode) {
     if (obj == null) {
       throw CommonException.of(resultcode);
     }
     return obj;
+  }
+
+  private CommonException() {
+    super(ResultCode.ERROR.desc());
+    this.resultCode = ResultCode.ERROR;
   }
 
   private CommonException(final String message) {
@@ -66,24 +80,16 @@ public class CommonException extends RuntimeException {
     this.resultCode = resultCode;
   }
 
-  private CommonException() {
-    super(ResultCode.ERROR.desc());
-    this.resultCode = ResultCode.ERROR;
-  }
-
   private CommonException(final String message, final Throwable cause) {
     super(message, cause);
   }
 
-  private CommonException(final Throwable cause) {
-    super(cause);
+  private CommonException(@Nonnull final ResultCode resultCode, final Throwable cause) {
+    super(resultCode.desc(), cause);
+    this.resultCode = resultCode;
   }
 
-  protected CommonException(
-      final String message,
-      final Throwable cause,
-      final boolean enableSuppression,
-      final boolean writableStackTrace) {
-    super(message, cause, enableSuppression, writableStackTrace);
+  private CommonException(final Throwable cause) {
+    super(cause);
   }
 }

--- a/wind-core/src/main/java/io/github/ramerf/wind/core/exception/GlobalExceptionHandler.java
+++ b/wind-core/src/main/java/io/github/ramerf/wind/core/exception/GlobalExceptionHandler.java
@@ -58,7 +58,7 @@ public class GlobalExceptionHandler {
     log.error(request.getRequestURL().toString());
     handleError(request, exception);
     final ResultCode resultCode = ((CommonException) exception).getResultCode();
-    return Objects.isNull(resultCode) ? Rs.fail(exception.getMessage()) : Rs.fail(resultCode);
+    return resultCode == null ? Rs.fail(exception.getMessage()) : Rs.fail(resultCode);
   }
 
   /**
@@ -197,7 +197,7 @@ public class GlobalExceptionHandler {
   public Rs<Object> handleDataAccessException(HttpServletRequest request, Exception exception) {
     if (exception instanceof IncorrectResultSizeDataAccessException) {
       handleError(request, exception);
-      return Rs.fail(ResultCode.API_TOO_MANY_RESULTS);
+      return Rs.tooManyResults();
     }
     final Throwable cause = exception.getCause();
     if (cause instanceof SQLException) {

--- a/wind-core/src/main/java/io/github/ramerf/wind/core/handler/typehandler/ITypeHandler.java
+++ b/wind-core/src/main/java/io/github/ramerf/wind/core/handler/typehandler/ITypeHandler.java
@@ -39,7 +39,13 @@ public interface ITypeHandler<T, V> {
   Object convertToJdbc(final T t, final Field field, @Nonnull final PreparedStatement ps);
 
   /**
-   * 数据库值转换为Java对象值
+   * 数据库值转换为Java对象值<br>
+   *
+   * <pre>
+   * TODO POST 如果有必要的话,这里可以加个参数 [集合初始值],允许用户自定义集合类型.<br>
+   *  比如用户定义字段: {@code private Set<Long> ids = new TreeSet<>();},
+   *  那么查询数据返回的类型就会是TreeSet,现在如果查询数据不为空默认是HashSet,不够通用
+   * </pre>
    *
    * @param value 数据库值
    * @param clazz Java对象类型

--- a/wind-core/src/main/java/io/github/ramerf/wind/core/service/QueryService.java
+++ b/wind-core/src/main/java/io/github/ramerf/wind/core/service/QueryService.java
@@ -83,7 +83,7 @@ public interface QueryService<T extends AbstractEntityPoJo<T, ID>, ID extends Se
   }
 
   /**
-   * 获取单个PoJo对象.
+   * 获取单个对象.
    *
    * @param consumer 查询条件
    * @return the ones
@@ -106,7 +106,7 @@ public interface QueryService<T extends AbstractEntityPoJo<T, ID>, ID extends Se
   }
 
   /**
-   * 获取单个PoJo对象.
+   * 获取单个对象.
    *
    * @param query 查询字段
    * @param condition 查询条件
@@ -176,7 +176,7 @@ public interface QueryService<T extends AbstractEntityPoJo<T, ID>, ID extends Se
   }*/
 
   /**
-   * 通过id集合查询PoJo列表.
+   * 通过id集合查询列表.
    *
    * @param ids the ids
    * @return the list
@@ -199,7 +199,7 @@ public interface QueryService<T extends AbstractEntityPoJo<T, ID>, ID extends Se
   }
 
   /**
-   * 查询PoJo列表.
+   * 查询列表.
    *
    * @param consumer the consumer
    * @return the list
@@ -222,7 +222,7 @@ public interface QueryService<T extends AbstractEntityPoJo<T, ID>, ID extends Se
   }
 
   /**
-   * 查询指定字段,返回PoJo列表.
+   * 查询指定字段.
    *
    * @param queryConsumer 查询列
    * @param conditionConsumer 查询条件
@@ -252,12 +252,12 @@ public interface QueryService<T extends AbstractEntityPoJo<T, ID>, ID extends Se
   }
 
   /**
-   * 获取某页列表数据,返回PoJo对象.
+   * 获取某页列表数据.
    *
    * @param conditionConsumer 查询条件
    * @param page 当前页码,从1开始
    * @param size 每页大小
-   * @return PoJo对象列表 list
+   * @return 对象列表 list
    */
   default List<T> list(
       final Consumer<LambdaCondition<T>> conditionConsumer, final int page, final int size) {
@@ -265,12 +265,12 @@ public interface QueryService<T extends AbstractEntityPoJo<T, ID>, ID extends Se
   }
 
   /**
-   * 获取某页列表数据,返回PoJo对象.
+   * 获取某页列表数据.
    *
    * @param conditionConsumer 查询条件
    * @param page 当前页码,从1开始
    * @param size 每页大小
-   * @return PoJo对象列表 list
+   * @return 对象列表 list
    */
   default List<T> list(
       final Consumer<LambdaCondition<T>> conditionConsumer,
@@ -310,8 +310,13 @@ public interface QueryService<T extends AbstractEntityPoJo<T, ID>, ID extends Se
         .fetchAll(clazz, pageable);
   }
 
+  /** 查询列表. */
+  default List<T> listAll() {
+    return listAll(null, getPoJoClass());
+  }
+
   /**
-   * 查询PoJo列表.
+   * 查询列表.
    *
    * @param queryConsumer 查询列
    * @return the list
@@ -350,7 +355,7 @@ public interface QueryService<T extends AbstractEntityPoJo<T, ID>, ID extends Se
    * @param conditionConsumer 查询条件
    * @param page 当前页码,从1开始
    * @param size 每页大小
-   * @return PoJo分页数据 page
+   * @return 分页数据 page
    */
   default Page<T> page(
       final Consumer<LambdaCondition<T>> conditionConsumer, final int page, final int size) {
@@ -364,7 +369,7 @@ public interface QueryService<T extends AbstractEntityPoJo<T, ID>, ID extends Se
    * @param page 当前页码,从1开始
    * @param size 每页大小
    * @param sortColumn 排序规则
-   * @return PoJo分页数据 page
+   * @return 分页数据 page
    */
   default Page<T> page(
       final Consumer<LambdaCondition<T>> conditionConsumer,
@@ -395,7 +400,7 @@ public interface QueryService<T extends AbstractEntityPoJo<T, ID>, ID extends Se
   }
 
   /**
-   * 查询分页,返回PoJo对象.
+   * 查询分页.
    *
    * @param queryConsumer 查询列
    * @param conditionConsumer 查询条件

--- a/wind-core/src/main/java/io/github/ramerf/wind/core/support/EntityInfo.java
+++ b/wind-core/src/main/java/io/github/ramerf/wind/core/support/EntityInfo.java
@@ -66,8 +66,7 @@ public final class EntityInfo {
   private List<MappingInfo> mappingInfos = new ArrayList<>();
 
   /** TODO WARN 保存字段的写入方法，更新时可以避免使用反射. */
-  private Map<Field, IConsumer<?, ?>> writeMethods =
-      Collections.synchronizedMap(new TreeMap<>((o1, o2) -> o1.equals(o2) ? 0 : 1));
+  private Map<Field, IConsumer<?, ?>> writeMethods;
 
   private Dialect dialect;
 

--- a/wind-core/src/main/java/io/github/ramerf/wind/core/type/JavaType.java
+++ b/wind-core/src/main/java/io/github/ramerf/wind/core/type/JavaType.java
@@ -3,6 +3,7 @@ package io.github.ramerf.wind.core.type;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Set;
 
 import static io.github.ramerf.wind.core.util.TypeUtils.getType;
 
@@ -20,6 +21,14 @@ public interface JavaType {
   Type LIST_DOUBLE = getType(List.class, Double.class);
   Type LIST_BIGDECIMAL = getType(List.class, BigDecimal.class);
   Type LIST_STRING = getType(List.class, String.class);
+
+  Type SET_SHORT = getType(Set.class, Short.class);
+  Type SET_INTEGER = getType(Set.class, Integer.class);
+  Type SET_LONG = getType(Set.class, Long.class);
+  Type SET_FLOAT = getType(Set.class, Float.class);
+  Type SET_DOUBLE = getType(Set.class, Double.class);
+  Type SET_BIGDECIMAL = getType(Set.class, BigDecimal.class);
+  Type SET_STRING = getType(Set.class, String.class);
 
   /**
    * 可映射的数据库类型.

--- a/wind-core/src/test/resources/application.yml
+++ b/wind-core/src/test/resources/application.yml
@@ -73,13 +73,13 @@ logging:
     jdbc.sqltiming: info
 wind:
   logic-delete-prop:
-    # 是否启用逻辑删除,可以在类上使用@TableInfo的enableLogicDelete属性覆盖,添加@TableInfo注解会使该配置失效
+    # 是否启用逻辑删除,可以在类上使用@TableInfo的enableLogicDelete属性覆盖
     enable: true
-    # 逻辑删除字段名,添加@TableInfo注解会使该配置失效
+    # 逻辑删除字段名
     field-name: deleted
-    # 逻辑未删除值(默认为 false),添加@TableInfo注解会使该配置失效
+    # 逻辑未删除值(默认为 false)
     not-delete: false
-    # 逻辑已删除值(默认为 true),添加@TableInfo注解会使该配置失效
+    # 逻辑已删除值(默认为 true)
     deleted: true
   # 自动建表
   ddl-auto: update

--- a/wind-demo/pom.xml
+++ b/wind-demo/pom.xml
@@ -11,12 +11,12 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>wind-demo</artifactId>
     <name>wind-demo</name>
-    <version>4.0.2-RELEASE</version>
+    <version>4.0.3</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <druid.version>1.1.22</druid.version>
-        <wind.version>4.0.2-RELEASE</wind.version>
+        <wind.version>4.0.3</wind.version>
         <lombok.version>1.18.10</lombok.version>
         <postgresql.version>42.2.18</postgresql.version>
     </properties>

--- a/wind-demo/src/main/java/io/github/ramerf/wind/demo/entity/response/ResCode.java
+++ b/wind-demo/src/main/java/io/github/ramerf/wind/demo/entity/response/ResCode.java
@@ -4,19 +4,19 @@ import io.github.ramerf.wind.core.entity.response.ResultCode;
 import lombok.ToString;
 
 /**
- * 响应码,格式: 模块_操作状态_操作类型.
+ * 响应码.
  *
+ * @since 2020.12.22
  * @author Tang Xiaofeng
- * @since 2020/5/21
  */
 @ToString
 public class ResCode extends ResultCode {
-  public static final ResultCode FOO_SUCCESS_UPDATE = of("E9100", "更新成功!");
-  public static final ResultCode FOO_FAIL_UPDATE = of("E9101", "哇哦 \uD83D\uDE05,更新失败了,要不要重新试下 ?");
-  public static final ResultCode FOO_SUCCESS_DELETE = of("E9110", "删除成功!");
-  public static final ResultCode FOO_FAIL_DELETE = of("E9111", "哇哦 \uD83D\uDE05,删除失败了,要不要重新试下 ?");
+  public static final ResultCode FOO_SUCCESS_UPDATE = of(9100, "更新成功!");
+  public static final ResultCode FOO_FAIL_UPDATE = of(9101, "哇哦 \uD83D\uDE05,更新失败了,要不要重新试下 ?");
+  public static final ResultCode FOO_SUCCESS_DELETE = of(9110, "删除成功!");
+  public static final ResultCode FOO_FAIL_DELETE = of(9111, "哇哦 \uD83D\uDE05,删除失败了,要不要重新试下 ?");
 
-  protected ResCode(final String code, final String desc) {
+  protected ResCode(final int code, final String desc) {
     super(code, desc);
   }
 }

--- a/wind-demo/src/main/resources/application.yml
+++ b/wind-demo/src/main/resources/application.yml
@@ -77,13 +77,13 @@ logging:
     jdbc.sqltiming: info
 wind:
   logic-delete-prop:
-    # 是否启用逻辑删除,可以在类上使用@TableInfo的enableLogicDelete属性覆盖,添加@TableInfo注解会使该配置失效
-    enable: false
-    # 逻辑删除字段名,添加@TableInfo注解会使该配置失效
+    # 是否启用逻辑删除,可以在类上使用@TableInfo的enableLogicDelete属性覆盖
+    enable: true
+    # 逻辑删除字段名
     field-name: deleted
-    # 逻辑未删除值(默认为 false),添加@TableInfo注解会使该配置失效
+    # 逻辑未删除值(默认为 false)
     not-delete: false
-    # 逻辑已删除值(默认为 true),添加@TableInfo注解会使该配置失效
+    # 逻辑已删除值(默认为 true)
     deleted: true
   # 自动建表
   ddl-auto: update


### PR DESCRIPTION
- 新增：更新指定字段
- 新增：查询支持
- 新增：字符串条件构造`StringCondition`。如：`condition.eq("id", 1);`
- 新增：主键支持任意类型
- 新增：条件组，拼接or条件更清晰
- 新增：`GenericService`支持操作任意表
- 新增：支持内存缓存。通过`wind.cache.type=memory`开启
- 新增：实体现在自带保存/更新方法 `product.create();`
- 新增：校验器工具类
- 新增：全局异常处理
- 新增：Postgresql支持Set字段
- 更新：默认关闭缓存
- 更新：默认关闭逻辑删除
- 更新：默认写入所有(包括null值)属性，通过`wind.write-null-prop=true/false`开关
- 更新：InterEnum枚举值由整型改为泛型。controller枚举支持接收名称和value值
- 更新：`@Column`替换为`@TableColumn`
- 更新：弃用`@Entity`，使用`@TableInfo`
- 更新：其他易用性更新
- 优化：缓存清除时改为使用scan指令
- 修复：字段为boolean时，lambda无法获取到field
- 修复：缓存没有正确清除